### PR TITLE
Add DPP field to inventory dialogs

### DIFF
--- a/app/Models/Items.php
+++ b/app/Models/Items.php
@@ -27,7 +27,8 @@ class Items extends Model
         'tax_percentage_wholesale',
         'tax_percentage_eceran',
         'semi_grosir_price', 'tax_percentage_semi_grosir','pajak_luaran_semi_grosir',
-        'status_perubahan_harga', 'selisih_perubahan_harga'
+        'status_perubahan_harga', 'selisih_perubahan_harga',
+        'dpp'
     ];
     protected static function booted()
     {

--- a/app/Models/Pembelian.php
+++ b/app/Models/Pembelian.php
@@ -101,6 +101,26 @@ class Pembelian extends Model
             }
         });
 
+        static::saved(function ($pembelian) {
+            self::syncItemDpp($pembelian->kode_barang);
+        });
 
+        static::deleted(function ($pembelian) {
+            self::syncItemDpp($pembelian->kode_barang);
+        });
+
+    }
+
+    protected static function syncItemDpp(string $kodeBarang): void
+    {
+        $item = \App\Models\Items::where('item_code', $kodeBarang)->first();
+        if ($item) {
+            $latest = self::where('kode_barang', $kodeBarang)
+                ->orderBy('tanggal_pembelian', 'desc')
+                ->first();
+
+            $item->dpp = $latest?->harga_total;
+            $item->save();
+        }
     }
 }

--- a/database/migrations/2025_06_27_120000_add_dpp_to_items_table.php
+++ b/database/migrations/2025_06_27_120000_add_dpp_to_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->decimal('dpp', 15, 2)->nullable()->after('selisih_perubahan_harga');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropColumn(['dpp']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,7 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         $this->call(RoleAndPermissionSeeder::class);
+        $this->call(UpdateItemDppSeeder::class);
 
     }
 }

--- a/database/seeders/UpdateItemDppSeeder.php
+++ b/database/seeders/UpdateItemDppSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Items;
+use App\Models\Pembelian;
+
+class UpdateItemDppSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Items::chunk(100, function ($items) {
+            foreach ($items as $item) {
+                $latest = Pembelian::where('kode_barang', $item->item_code)
+                    ->orderBy('tanggal_pembelian', 'desc')
+                    ->first();
+
+                if ($latest) {
+                    $item->dpp = $latest->harga_total;
+                    $item->save();
+                }
+            }
+        });
+    }
+}

--- a/resources/js/Components/Inventory/DialogEditBarang.jsx
+++ b/resources/js/Components/Inventory/DialogEditBarang.jsx
@@ -58,7 +58,8 @@ export function DialogEditBarang({barang, dataSatuan, setError, setSuccess}) {
         pajak_luaran_retail: barang.pajak_luaran_retail,
         pajak_luaran_semi_grosir: barang.pajak_luaran_semi_grosir,
         pajak_luaran_wholesale: barang.pajak_luaran_wholesale,
-        pajak_luaran_eceran: barang.pajak_luaran_eceran
+        pajak_luaran_eceran: barang.pajak_luaran_eceran,
+        dpp: barang.dpp
     });
 
     const [loading, setLoading] = useState(false);
@@ -255,8 +256,9 @@ export function DialogEditBarang({barang, dataSatuan, setError, setSuccess}) {
             tax: barang.tax,
             pajak_luaran_retail: barang.pajak_luaran_retail,
             pajak_luaran_semi_grosir: barang.pajak_luaran_semi_grosir,
-            pajak_luaran_wholesale: barang.pajak_luaran_wholesale,
-            pajak_luaran_eceran: barang.pajak_luaran_eceran
+        pajak_luaran_wholesale: barang.pajak_luaran_wholesale,
+        pajak_luaran_eceran: barang.pajak_luaran_eceran,
+        dpp: barang.dpp
         });
         setInputValue(""); // Reset inputValue untuk pencarian kategori
         setSearchTerm(""); // Reset searchTerm
@@ -548,11 +550,18 @@ export function DialogEditBarang({barang, dataSatuan, setError, setSuccess}) {
                             </PopoverContent>
                         </Popover>
                     </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
+                   <div className="grid grid-cols-4 items-center gap-4">
                         <Label htmlFor="harga" className="text-right">
                             Harga Modal
                         </Label>
                         <Input id="harga" value={formatRupiah(data.harga)} onChange={handlePriceChange}
+                               className="col-span-3"/>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="dpp" className="text-right">
+                            DPP
+                        </Label>
+                        <Input id="dpp" readOnly value={formatRupiah(data.dpp)}
                                className="col-span-3"/>
                     </div>
                     <div className="grid grid-cols-4 items-center gap-4">

--- a/resources/js/Components/Inventory/DialogTambahBarang.jsx
+++ b/resources/js/Components/Inventory/DialogTambahBarang.jsx
@@ -61,7 +61,8 @@ export function DialogTambahBarang({auth, setError, setSuccess, dataSatuan}) {
         retail_convertion: "",
         is_tax: false,
         is_retail: false,
-        tax: ""
+        tax: "",
+        dpp: 0
     });
 
     const [loading, setLoading] = useState(false);
@@ -323,7 +324,8 @@ export function DialogTambahBarang({auth, setError, setSuccess, dataSatuan}) {
             bulk_spec: "",
             retail_convertion: "",
             is_tax: false,
-            tax: ""
+            tax: "",
+            dpp: 0
         });
         setInputValue(""); // Reset inputValue untuk pencarian kategori
         setSearchTerm(""); // Reset searchTerm
@@ -518,6 +520,13 @@ export function DialogTambahBarang({auth, setError, setSuccess, dataSatuan}) {
                             Harga Modal
                         </Label>
                         <Input id="harga" value={formatRupiah(data.harga_beli)} onChange={handlePriceChange}
+                               className="col-span-3"/>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="dpp" className="text-right">
+                            DPP
+                        </Label>
+                        <Input id="dpp" readOnly value={formatRupiah(data.dpp)}
                                className="col-span-3"/>
                     </div>
                     <div className="grid grid-cols-4 items-center gap-4">


### PR DESCRIPTION
## Summary
- expose `dpp` value in inventory item forms
- show read‑only DPP input when editing or adding items

## Testing
- `php artisan migrate` *(fails: `php` not found)*
- `./vendor/bin/phpunit --version` *(fails: `phpunit` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e1a7569a48324a81514a20b8848e9