### PR TITLE
Fix tax exclusion when retail

### DIFF
--- a/app/Models/InvoiceItems.php
+++ b/app/Models/InvoiceItems.php
@@ -162,11 +162,12 @@ class InvoiceItems extends Model
                 );
                 $isUnitExcluded = $item->price_type === 'eceran' && in_array($unit, $excludedUnits);
 
-                // Tambahkan pengecualian untuk barang berpajak
+                // Tambahkan pengecualian untuk barang berpajak dan dijual eceran
                 $isTaxed = $itemModel->is_tax ?? false;
+                $isTaxedExcluded = $isTaxed && $item->price_type === 'eceran';
 
                 // Update kondisi pengecualian
-                $shouldExclude = $isCategoryExcluded || $isItemNameExcluded || $isUnitExcluded || $isTaxed;
+                $shouldExclude = $isCategoryExcluded || $isItemNameExcluded || $isUnitExcluded || $isTaxedExcluded;
 
                 if (fmod($item->qty, 1) === 0.5 && !$shouldExclude) {
                     $item->sub_total += 5000;


### PR DESCRIPTION
## Summary
- handle invoice item exclusion when item is taxed and sold with `eceran` price type

## Testing
- `php artisan test` *(fails: required vendor packages are missing)*


------
https://chatgpt.com/codex/tasks/task_b_685e825309c88324a3543fc22398d0af