### PR TITLE
Show price change indicators for purchases

### DIFF
--- a/app/Http/Controllers/InventoryController.php
+++ b/app/Http/Controllers/InventoryController.php
@@ -261,7 +261,7 @@ class InventoryController extends Controller
 
             return response()->json([
                 'message' => 'Item berhasil ditambahkan',
-                'item' => $pembelian,
+                'pembelian' => $pembelian->load(['category', 'item']),
                 'category' => $category,
             ], 201);
         } catch (\Exception $e) {
@@ -330,7 +330,7 @@ class InventoryController extends Controller
 
             return response()->json([
                 'message' => 'Item berhasil diperbarui',
-                'item' => $pembelian,
+                'pembelian' => $pembelian->load(['category', 'item']),
                 'category' => $category,
             ], 200);
 

--- a/resources/js/Components/Inventory/table/column.jsx
+++ b/resources/js/Components/Inventory/table/column.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {createColumnHelper} from "@tanstack/react-table";
-import {MoreHorizontal, CircleArrowUp, CircleArrowDown} from "lucide-react"
+import {CircleArrowUp, CircleArrowDown} from "lucide-react"
 import {Button} from "@/Components/ui/button"
 import {
     DropdownMenu,


### PR DESCRIPTION
## Summary
- show price change status in purchase table using up/down icons and badge
- return related item price change fields in purchase API responses

## Testing
- `php artisan test` *(fails: Database file at path [/workspace/agung-besi-sentosa/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b90e655883228ec153489909a4a5